### PR TITLE
Fix Send/Recv function calls re: default values.

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -916,7 +916,7 @@ int BridgeManager::ReceivePitFile(unsigned char **pitBuffer) const
 	for (unsigned int i = 0; i < transferCount; i++)
 	{
 		DumpPartPitFilePacket *requestPacket = new DumpPartPitFilePacket(i);
-		success = SendPacket(requestPacket);
+		success = SendPacket(requestPacket, kDefaultTimeoutSend, kEmptyTransferNone);
 		delete requestPacket;
 
 		if (!success)
@@ -929,7 +929,7 @@ int BridgeManager::ReceivePitFile(unsigned char **pitBuffer) const
 		int receiveEmptyTransferFlags = (i == transferCount - 1) ? kEmptyTransferAfter : kEmptyTransferNone;
 		
 		ReceiveFilePartPacket *receiveFilePartPacket = new ReceiveFilePartPacket();
-		success = ReceivePacket(receiveFilePartPacket, receiveEmptyTransferFlags);
+		success = ReceivePacket(receiveFilePartPacket, kDefaultTimeoutReceive, receiveEmptyTransferFlags);
 		
 		if (!success)
 		{


### PR DESCRIPTION
Default parameter values in SendPacket and ReceivePacket
were leading to confusion in the ReceivePit function.
Empty transfer flags were passed in as timeouts.

Additionally, on the GS5, empty transfers
aren't required around the send ack packets
during Pit retrieval, and actually screw up
the state breaking the remainder of
the session.
